### PR TITLE
Fix SEARCH/ACCESS issue for LIDVID resource references

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
   <groupId>gov.nasa.pds.2010.portal</groupId>
   <artifactId>ds-view</artifactId>
-  <version>2.14.2</version>
+  <version>2.14.3</version>
   <packaging>war</packaging>
 
   <name>Data Set View</name>

--- a/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
@@ -202,7 +202,7 @@ public class PDS4Search {
 		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
-		params.add("q", "identifier:" + cleanIdentifier(identifier));
+        params.add("q", "identifier:" + cleanIdentifier(identifier));
 		params.set("indent", "on");
 		params.set("wt", "xml");
 
@@ -271,7 +271,8 @@ public class PDS4Search {
       }
 
       for (String resourceRef : resourceRefList) {
-        params.add("q", "identifier:" + cleanIdentifier(resourceRef));
+        params.clear();
+        params.add("q", "identifier:" + cleanIdentifier(getLID(resourceRef)));
         params.set("indent", "on");
         params.set("wt", "xml");
 
@@ -288,7 +289,6 @@ public class PDS4Search {
         while (itr.hasNext()) {
           doc = itr.next();
           log.info("*****************  idx = " + (idx++));
-          // log.info(doc.toString());
 
           String resourceName = "";
           String resourceURL = "";
@@ -375,10 +375,18 @@ public class PDS4Search {
 			}
 		}
 	}
-	
-	private String cleanIdentifier(String identifier) {
-		return identifier.replace(":", "\\:").replace("\\\\", "\\");
-	}
+
+    private String cleanIdentifier(String identifier) {
+      return identifier.replace(":", "\\:").replace("\\\\", "\\");
+    }
+
+    private String getLID(String identifier) {
+      if (identifier.contains("::")) {
+        return identifier.substring(0, identifier.indexOf("::"));
+      }
+
+      return identifier;
+    }
 
 	/**
 	 * Command line invocation.

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -23,7 +23,7 @@
   <!-- Search Service base URL -->
   <context-param>
       <param-name>search.url</param-name>
-      <param-value>http://localhost:8983/solr/data</param-value>
+      <param-value>http://localhost:8080/search-service</param-value>
   </context-param>
 
   <!-- DOI Service base URL -->


### PR DESCRIPTION
<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Update getResourceLinks to support lidvids
* new getLID method to parse LIDVIDs if they exist
* clear params when >1 resources

## ⚙️ Test Data and/or Report
* Loaded some data into prod1
<img width="1230" alt="Screenshot 2023-10-13 at 2 17 17 PM" src="https://github.com/NASA-PDS/ds-view/assets/33492486/4a9b9c53-f5c7-4d61-a760-37a49bb6484c">

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
Resolves #12 

