### PR TITLE
Fix memory leaks with Solr client connections for Solr 9

### DIFF
--- a/src/main/java/gov/nasa/pds/dsview/registry/PDS3Search.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/PDS3Search.java
@@ -14,29 +14,30 @@
 
 package gov.nasa.pds.dsview.registry;
 
-import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.impl.HttpSolrClient;
-import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.params.ModifiableSolrParams;
-import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrDocumentList;
-import org.codehaus.jettison.json.JSONArray;
-import org.codehaus.jettison.json.JSONException;
-import org.codehaus.jettison.json.JSONObject;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.*;
-import java.util.List;
-import java.util.Iterator;
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Collection;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.logging.Logger;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.params.ModifiableSolrParams;
+import org.codehaus.jettison.json.JSONArray;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
 
 /**
  * This class is used by the PDS data set view web interface to retrieve values
@@ -47,18 +48,20 @@ import java.util.logging.Logger;
 public class PDS3Search {
 
 	private static Logger log = Logger.getLogger(PDS3Search.class.getName());
-	static String solrServerUrl = "http://pdsdev.jpl.nasa.gov:8080/search-service/";
-
+    static String solrServerUrl = "http://pdsdev.jpl.nasa.gov:8080/search-service/";
 	public static final String DOI_SERVER_URL = "https://pds.nasa.gov/api/doi/0.2/dois";
 	/**
 	 * Constructor.
 	 */
 	public PDS3Search(String url) {
-		this.solrServerUrl = url;
+      solrServerUrl = url;
 	}
 
 	public SolrDocumentList getDataSetList() throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+	  HttpSolrClient solr = null;
+	  
+	  try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -93,10 +96,16 @@ public class PDS3Search {
 			}
 		}
 		return solrResults;
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getDataSet(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+	    HttpSolrClient solr = null;
+	      
+	      try {
+	        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 		
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -142,10 +151,16 @@ public class PDS3Search {
 			doc = dsDocs.get(returnIdx);
 		}
 		return doc;
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getMission(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+	    HttpSolrClient solr = null;
+	      
+	      try {
+	        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -177,13 +192,18 @@ public class PDS3Search {
 			}
 			instDocs.add(doc);
 		}		
-		//if (idx>1)
-		//	doc = instDocs.get(0);
 		return doc;
+
+      } finally {
+        solr.close();
+      }
 	}
 
 	public SolrDocument getInstHost(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+	      
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -216,13 +236,18 @@ public class PDS3Search {
 			}
 			instDocs.add(doc);
 		}
-		//if (idx>1)
-		//	doc = instDocs.get(0);
-		return doc;
+        return doc;
+
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public List<SolrDocument> getInst(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+	      
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -255,10 +280,17 @@ public class PDS3Search {
 			instDocs.add(doc);
 		}
 		return instDocs;
+
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getInst(String instId, String instHostId) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+	      
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -289,10 +321,17 @@ public class PDS3Search {
 			}
 		}
 		return doc;
+
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getTarget(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+	      
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -326,10 +365,17 @@ public class PDS3Search {
 		if (idx>1)
 			doc = instDocs.get(0);
 		return doc;
+
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getResource(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+	      
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -360,20 +406,21 @@ public class PDS3Search {
 			}
 		}
 		return doc;
+
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public List<String> getValues(SolrDocument doc, String key) {
 		Collection<Object> values = doc.getFieldValues(key);
 		
 		if (values==null || values.size()==0) {
-			//log.info("key = " + key + "   values = " + values);
 			return null;
 		}
 		
 		List<String> results = new ArrayList<String>();
 		for (Object obj: values) {
-			
-			//log.info("------------values = " + values.toString());
 			if (obj instanceof java.util.Date) {
 				DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss.SSS'Z'");
 				df.setTimeZone(TimeZone.getTimeZone("GMT"));

--- a/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
@@ -61,7 +61,9 @@ public class PDS4Search {
 	}
 
 	public SolrDocumentList getCollections() throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+	  HttpSolrClient solr = null;
+	  try {
+		solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -92,11 +94,17 @@ public class PDS4Search {
 						+ "       Value = " + entry.getValue());
 			}
 		}
-		return solrResults;
+
+        return solrResults;
+      } finally {
+        solr.close();
+      }
 	}
 
 	public SolrDocumentList getBundles() throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -125,11 +133,16 @@ public class PDS4Search {
 						+ "       Value = " + entry.getValue());
 			}
 		}
-		return solrResults;
+        return solrResults;
+      } finally {
+        solr.close();
+      }
 	}
 
 	public SolrDocumentList getObservationals(int start) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 		
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -161,11 +174,16 @@ public class PDS4Search {
 						+ "       Value = " + entry.getValue());
 			}
 		}
-		return solrResults;
+        return solrResults;
+      } finally {
+        solr.close();
+      }
 	}
 
 	public SolrDocumentList getDocuments() throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
@@ -195,11 +213,16 @@ public class PDS4Search {
 						+ "       Value = " + entry.getValue());
 			}
 		}
-		return solrResults;
+        return solrResults;
+      } finally {
+        solr.close();
+      }
 	}
 	
 	public SolrDocument getContext(String identifier) throws SolrServerException, IOException {
-		HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
+      HttpSolrClient solr = null;
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
 		ModifiableSolrParams params = new ModifiableSolrParams();
 
 		params.add("q", "identifier:" + cleanIdentifier(identifier));
@@ -227,6 +250,9 @@ public class PDS4Search {
 			}
 		}
 		return doc;
+      } finally {
+        solr.close();
+      }
 	}
 
 	public List<String> getValues(SolrDocument doc, String key) {
@@ -260,50 +286,55 @@ public class PDS4Search {
 
     public Map<String, String> getResourceLinks(List<String> resourceRefList)
         throws SolrServerException, IOException {
-      HttpSolrClient solr = new HttpSolrClient.Builder(solrServerUrl).build();
-      ModifiableSolrParams params = new ModifiableSolrParams();
+      HttpSolrClient solr = null;
+      try {
+        solr = new HttpSolrClient.Builder(solrServerUrl).build();
+        ModifiableSolrParams params = new ModifiableSolrParams();
 
-      log.info("getResourceLinks");
-      Map<String, String> resourceMap = new HashMap<String, String>();
+        log.info("getResourceLinks");
+        Map<String, String> resourceMap = new HashMap<String, String>();
 
-      if (resourceRefList == null) {
-        return resourceMap;
-      }
-
-      for (String resourceRef : resourceRefList) {
-        params.add("q", "identifier:" + cleanIdentifier(resourceRef));
-        params.set("indent", "on");
-        params.set("wt", "xml");
-
-        log.info("params = " + params.toString());
-        QueryResponse response =
-            solr.query(params, org.apache.solr.client.solrj.SolrRequest.METHOD.GET);
-
-        SolrDocumentList solrResults = response.getResults();
-        log.info("numFound = " + solrResults.getNumFound());
-
-        Iterator<SolrDocument> itr = solrResults.iterator();
-        SolrDocument doc = null;
-        int idx = 0;
-        while (itr.hasNext()) {
-          doc = itr.next();
-          log.info("*****************  idx = " + (idx++));
-          // log.info(doc.toString());
-
-          String resourceName = "";
-          String resourceURL = "";
-          for (Map.Entry<String, Object> entry : doc.entrySet()) {
-            if (entry.getKey().equals("resource_name")) {
-              resourceName = getValue(entry);
-            } else if (entry.getKey().equals("resLocation")) {
-              resourceURL = getValue(entry);
-            }
-          }
-          log.info("resname = " + resourceName + "       reslink = " + resourceURL);
-          resourceMap.put(resourceName, resourceURL);
+        if (resourceRefList == null) {
+          return resourceMap;
         }
+
+        for (String resourceRef : resourceRefList) {
+          params.add("q", "identifier:" + cleanIdentifier(resourceRef));
+          params.set("indent", "on");
+          params.set("wt", "xml");
+
+          log.info("params = " + params.toString());
+          QueryResponse response =
+              solr.query(params, org.apache.solr.client.solrj.SolrRequest.METHOD.GET);
+
+          SolrDocumentList solrResults = response.getResults();
+          log.info("numFound = " + solrResults.getNumFound());
+
+          Iterator<SolrDocument> itr = solrResults.iterator();
+          SolrDocument doc = null;
+          int idx = 0;
+          while (itr.hasNext()) {
+            doc = itr.next();
+            log.info("*****************  idx = " + (idx++));
+            // log.info(doc.toString());
+
+            String resourceName = "";
+            String resourceURL = "";
+            for (Map.Entry<String, Object> entry : doc.entrySet()) {
+              if (entry.getKey().equals("resource_name")) {
+                resourceName = getValue(entry);
+              } else if (entry.getKey().equals("resLocation")) {
+                resourceURL = getValue(entry);
+              }
+            }
+            log.info("resname = " + resourceName + "       reslink = " + resourceURL);
+            resourceMap.put(resourceName, resourceURL);
+          }
+        }
+        return resourceMap;
+      } finally {
+        solr.close();
       }
-      return resourceMap;
     }
 
     private String getValue(Map.Entry<String, Object> entry) {
@@ -339,6 +370,7 @@ public class PDS4Search {
 			log.info("getDoiResponse's responseCode != 200");
 			return null;
 		}
+
 	}
 
 	public String getDoi(String lid, String vid) throws IOException, JSONException {


### PR DESCRIPTION
Fix memory leaks for solr connection left open.

Not sure why this wasn't an issue before. Maybe Tomcat would kill these threads after so long, and since we are getting pummeled with queries, the threads didn't have a chance to die.

Either way, closing the solr client connections each time seems to fix it.

Cherry-picked from `hotfix/2.14.4` branch and `v2.14.4` release

Fixes #14
Refs #15

See #15 for more details