### PR TITLE
Fixed a bug in resource_ref handling when there is more than one resource

### DIFF
--- a/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/PDS4Search.java
@@ -283,7 +283,7 @@ public class PDS4Search {
       Http2SolrClient solr = null;
       try {
         solr = new Http2SolrClient.Builder(solrServerUrl).build();
-        ModifiableSolrParams params = new ModifiableSolrParams();
+        ModifiableSolrParams params = null;
 
         Map<String, String> resourceMap = new HashMap<String, String>();
 
@@ -292,6 +292,7 @@ public class PDS4Search {
         }
 
         for (String resourceRef : resourceRefList) {
+          params = new ModifiableSolrParams();
           params.add("q", "identifier:" + cleanIdentifier(resourceRef));
           params.set("wt", "xml");
 


### PR DESCRIPTION


<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Fix bug in resource_ref handling for >1 resource

## ⚙️ Test Data and/or Report
<img width="874" alt="Screenshot 2025-01-09 at 8 41 19 AM" src="https://github.com/user-attachments/assets/858acf8a-8bd1-4807-a5fc-f825bf2be396" />


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->

Resolves #40
