### PR TITLE
Update viewProfile to support new resource handling

### DIFF
--- a/src/main/java/gov/nasa/pds/dsview/registry/Constants.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/Constants.java
@@ -130,7 +130,6 @@ public class Constants {
           dsPds3ToSearch.put("CITATION_DESCRIPTION", "citation_description");
           dsPds3ToSearch.put("ABSTRACT_TEXT", "abstract_text");
           dsPds3ToSearch.put("PRODUCER_FULL_NAME", "full_name"); // node_to_data_archivist reference????? person_name
-          dsPds3ToSearch.put("SEARCH/ACCESS DATA", "resource_ref");
     }
       
     public static final Map<String, String> instPds3ToRegistry = 

--- a/src/main/webapp/pds/viewProfile.jsp
+++ b/src/main/webapp/pds/viewProfile.jsp
@@ -54,17 +54,7 @@ else {
    PDS3Search pds3Search = new PDS3Search(searchUrl);
    
    String tmpDsid = dsid.toLowerCase();
-   /*
-   //dsid = tmpDsid.replaceAll("%2F", "/");
-   tmpDsid = tmpDsid.replaceAll("%2F", "-");
-   tmpDsid = tmpDsid.replaceAll("/", "-");
-   tmpDsid = tmpDsid.replaceAll(" ", "_");
-   tmpDsid = tmpDsid.replaceAll("\\(", "");
-   tmpDsid = tmpDsid.replaceAll("\\)", "");
-   */
-   
-   //out.println("dsid = " + dsid + "    dsid_lower = " + dsid_lower);
-   
+
    try {
    	SolrDocument doc = pds3Search.getDataSet(tmpDsid.toLowerCase());
    	//SolrDocument doc = pds3Search.getDataSet("urn:nasa:pds:context_pds3:data_set:data_set."+tmpDsid.toLowerCase());
@@ -72,7 +62,7 @@ else {
    if (doc==null) { 
    %>
             <tr valign="TOP">
-               <td bgcolor="#F0EFEF" width=200 valign=top>
+               <td bgcolor="#E7EEF9" width=200 valign=top>
                   Information not found for dsid <b><%=dsid%></b>. Please verify the value.
                </td> 
             </tr>
@@ -82,11 +72,10 @@ else {
        for (java.util.Map.Entry<String, String> entry: Constants.dsPds3ToSearch.entrySet()) {
           String key = entry.getKey();
 	      String tmpValue = entry.getValue();
-	      //out.println("key = " + key + "   tmpValue = " + tmpValue);
           %>
             <TR>
-               <td bgcolor="#F0EFEF" width=200 valign=top><%=key%></td> 
-               <td bgcolor="#F0EFEF" valign=top>
+               <td bgcolor="#E7EEF9" width=200 valign=top><%=key%></td> 
+               <td bgcolor="#E7EEF9" valign=top>
           <% 
           String val = "";
           List<String> slotValues = pds3Search.getValues(doc, tmpValue);         
@@ -123,7 +112,6 @@ else {
     	    	   <%
     	        }
              }
-             //else if (tmpValue.equals("instrument_id") && !tmpValue.startsWith("instrument_host_")) {
              else if (tmpValue.equals("instrument_id")) {
                 List<String> svalues = pds3Search.getValues(doc, tmpValue);      	 
     	 		for (int j=0; j<svalues.size(); j++) {
@@ -152,42 +140,13 @@ else {
     	    	         // need to pass target_type, how to make sure the order with the target_name and target_type????
     	    	     %>
     	    	         <a href="/ds-view/pds/viewTargetProfile.jsp?TARGET_NAME=<%=val%>" target="_blank"><%=val%></a><br>
-    	            <%} // end for
+    	            <%
+					   } // end for
     	           } // end if
     	           else 
     	              out.println(val);
     	        }
              }
-             else if (tmpValue.equals("resource_ref")) {
-                List<String> rvalues = pds3Search.getValues(doc, tmpValue);           
-                String resname="", reslink="";
-                String refLid = "";
-                if (rvalues != null) {
-     	           for (int i=0; i<rvalues.size(); i++) {
-                      //out.println(rvalues.get(i) + "<br>");
-                      refLid = rvalues.get(i);
-                      if (refLid!=null) {
-                         if (refLid.indexOf("::")!=-1) {
-                            refLid = refLid.substring(0, refLid.indexOf("::"));   
-                         }
-                         //refLid = refLid.replace("context_pds3", "context");
-                         SolrDocument refDoc = pds3Search.getResource(refLid);
-                         if (refDoc!=null) {
-                            resname = pds3Search.getValues(refDoc, "resource_name").get(0);
-                            reslink = pds3Search.getValues(refDoc, "resource_url").get(0);
-                            
-                 %>
-                         <li><a href="<%=reslink%>" target="_new"><%=resname%></a><br>
-                 <% 
-                         }
-                         else {
-                            resname = refLid;
-                            reslink = refLid;
-                         }                                                            
-                      } // end if (refLid!=null)
-                   } // end for
-         	    }  // end if (rvalues!=null)  	
-             } // end resoure_id
              else if (tmpValue.startsWith("node_id")) {
                 List<String> svalues = pds3Search.getValues(doc, tmpValue);
                 if (svalues!=null) { 	 
@@ -213,6 +172,51 @@ else {
             </TR>     
       <%        
        } // for loop
+	  %>
+	   <tr bgcolor="#E7EEF9">
+	       <td>SEARCH/ACCESS DATA</td>
+	       <td>
+	       <% 
+	        List<String> resnameList = pds3Search.getValues(doc, "resource_name");
+	        List<String> reslinkList = pds3Search.getValues(doc, "resource_url");
+	
+			String reslink = "";
+			String resname = "";
+	        if (reslinkList !=null) {
+	           for (int i = 0; i < reslinkList.size(); i++) {
+	              reslink = reslinkList.get(i);
+				  resname = resnameList.get(i);
+	       %>
+	             <li><a href="<%=reslink%>" target="_new"><%=resname%></a><br>
+	       <%                                                       
+	           }  // end for
+	        } else {
+			List<String> rvalues = pds3Search.getValues(doc, "resource_ref");
+			 String refLid = "";
+			 if (rvalues !=null) {
+			    for (int i=0; i < rvalues.size(); i++) {
+			       refLid = rvalues.get(i);
+			       if (refLid!=null) {
+			          if (refLid.indexOf("::") != -1) {
+			             refLid = refLid.substring(0, refLid.indexOf("::"));   
+			          }
+	
+			          SolrDocument refDoc = pds3Search.getResource(refLid);
+			          if (refDoc!=null) {
+			             resname = pds3Search.getValues(refDoc, "resource_name").get(0);
+			             reslink = pds3Search.getValues(refDoc, "resource_url").get(0);
+		%>
+				<li><a href="<%=reslink%>" target="_new"><%=resname%></a><br>
+		<%                                                       
+		              } // end if
+				   } // end if
+	            }  // end for
+			  } // end if  
+			} // end if reslinkList !=null
+		%>
+	       </td>
+	    </tr>
+		<% 
    } // else
    } catch (Exception e) {
    }

--- a/src/main/webapp/pds/viewProfile.jsp
+++ b/src/main/webapp/pds/viewProfile.jsp
@@ -30,7 +30,7 @@
 <!-- Main content -->
 <div id="content">
    <div style="border-top: 1px solid white;">
-   <table align="center" bgColor="#FFFFFF" BORDER="0" CELLPADDING="10" CELLSPACING="0">
+   <table width="760" align="center" bgColor="#FFFFFF" BORDER="0" CELLPADDING="10" CELLSPACING="0">
    <tr>
       <td>
          <table width="760" border="0" cellspacing="3" cellpadding="2">
@@ -68,23 +68,23 @@ else {
             </tr>
    <% 
    }  // end if (doc==null)
-   else {         
+   else {
        for (java.util.Map.Entry<String, String> entry: Constants.dsPds3ToSearch.entrySet()) {
           String key = entry.getKey();
 	      String tmpValue = entry.getValue();
           %>
             <TR>
                <td bgcolor="#E7EEF9" width=200 valign=top><%=key%></td> 
-               <td bgcolor="#E7EEF9" valign=top>
+               <td bgcolor="#E7EEF9" width=560 valign=top>
           <% 
           String val = "";
-          List<String> slotValues = pds3Search.getValues(doc, tmpValue);         
-          if (slotValues!=null) {
+          List<String> slotValues = pds3Search.getValues(doc, tmpValue);
+          if (slotValues != null) {
              if (tmpValue.equals("data_set_description") ||
                  tmpValue.equals("confidence_level_note")) {                      
                 val = slotValues.get(0);
              %>
-                  <pre><tt><%=val%></tt></pre>
+                  <%=val%>
              <%
              }
              else if (tmpValue.equals("investigation_name")) {
@@ -96,56 +96,11 @@ else {
                          lid = lid.substring(0, lid.indexOf("::"));
     	      	      val = lid;
     	      %>
-    	           <a href="/ds-view/pds/viewMissionProfile.jsp?MISSION_NAME=<%=val%>" target="_blank"><%=val%></a><br>  	       	
+    	           <%=val%><br>  	       	
               <%   } // end for
                 } // end if
                 else 
                    out.println(val);
-             } 
-             else if (tmpValue.equals("instrument_host_id")) {
-                List<String> svalues = pds3Search.getValues(doc, tmpValue);     	 
-    	 		for (int j=0; j<svalues.size(); j++) {
-    	 		   String aValue = (String) svalues.get(j);
-    	   	       val = aValue;
-    	    	   %>
-    	    	   <a href="/ds-view/pds/viewHostProfile.jsp?INSTRUMENT_HOST_ID=<%=val%>" target="_blank"><%=val%></a><br> 
-    	    	   <%
-    	        }
-             }
-             else if (tmpValue.equals("instrument_id")) {
-                List<String> svalues = pds3Search.getValues(doc, tmpValue);      	 
-    	 		for (int j=0; j<svalues.size(); j++) {
-    	 		   String aValue = (String) svalues.get(j);
-    	    	   val = aValue;
-    	    	   
-    	    	   String instHostId = pds3Search.getValues(doc, "instrument_host_id").get(0);
-    	   		   if (instHostId!=null) {
-    	      %>
-    	              <a href="/ds-view/pds/viewInstrumentProfile.jsp?INSTRUMENT_ID=<%=val%>&INSTRUMENT_HOST_ID=<%=instHostId%>" target="_blank"><%=val%></a><br>  	       	
-              <%   }
-    	   		   else {              
-    	      %>
-    	              <a href="/ds-view/pds/viewInstrumentProfile.jsp?INSTRUMENT_ID=<%=val%>" target="_blank"><%=val%></a><br>  	       	
-              <%   }
-    	        }
-             }
-             else if (tmpValue.equals("target_name")) {
-                if (pds3Search.getValues(doc, tmpValue)!=null) {                   
-                   List<String> targetValues = pds3Search.getValues(doc, tmpValue);
-    		       val = "";
-    		       if (targetValues!=null && targetValues.size()>0) {
-    	 	          for (int i=0; i<targetValues.size(); i++) {
-    	 		         val = (String) targetValues.get(i);
-    	 		               	    	              
-    	    	         // need to pass target_type, how to make sure the order with the target_name and target_type????
-    	    	     %>
-    	    	         <a href="/ds-view/pds/viewTargetProfile.jsp?TARGET_NAME=<%=val%>" target="_blank"><%=val%></a><br>
-    	            <%
-					   } // end for
-    	           } // end if
-    	           else 
-    	              out.println(val);
-    	        }
              }
              else if (tmpValue.startsWith("node_id")) {
                 List<String> svalues = pds3Search.getValues(doc, tmpValue);
@@ -160,8 +115,14 @@ else {
     	        }
              }
              else {
+				List<String> tmpList = new ArrayList();
+				String value;
                 for (int j=0; j<slotValues.size(); j++) {
-                   out.println(slotValues.get(j) + "<br>");
+				   value = slotValues.get(j);
+				   if (!tmpList.contains(value)) {
+                   		out.println(value + "<br>");
+						tmpList.add(value);
+				   }
                 }
              }
              


### PR DESCRIPTION
viewProfile did not work for reading resource_name and resource_urls for newly loaded objects.

refs #45

<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
`viewProfile.jsp` was missed when trying to update these JSPs per the change in the way we are handling resources for PDS3 objects.

updated to now check for both `resource_ref` or `resource_url` and handle the resources accordingly.

## ⚙️ Test Data and/or Report
Go to https://pds.nasa.gov/ds-view/pds/viewProfile.jsp?dsid=GO-J-POS-6-SC-TRAJ-MOON-COORDS-V1.0

## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
#45 
