### PR TITLE
Updates to support List_Author and List_Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ src/test/temp/
 *.sublime-*
 *.DS_Store
 pom.xml.versionsBackup
+*.vscode
 
 # Java stuff
 *.javac

--- a/src/main/java/gov/nasa/pds/dsview/registry/Constants.java
+++ b/src/main/java/gov/nasa/pds/dsview/registry/Constants.java
@@ -16,6 +16,9 @@ package gov.nasa.pds.dsview.registry;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
 /**
  * Class that holds constants used in ds-view.
  *
@@ -206,13 +209,43 @@ public class Constants {
     public static final Map<String, String> bundleCitationPds4ToRegistry =
       new LinkedHashMap<String, String>();
       static {
-				bundleCitationPds4ToRegistry.put("DIGITAL OBJECT IDENTIFIER (DOI)", "citation_doi");
-          bundleCitationPds4ToRegistry.put("AUTHOR LIST", "citation_author_list");
-	      bundleCitationPds4ToRegistry.put("EDITOR LIST", "citation_editor_list");
+		  bundleCitationPds4ToRegistry.put("DIGITAL OBJECT IDENTIFIER (DOI)", "citation_doi");
+          bundleCitationPds4ToRegistry.put("AUTHORS", "citation_author_list");
+	      bundleCitationPds4ToRegistry.put("EDITORS", "citation_editor_list");
 	      bundleCitationPds4ToRegistry.put("PUBLICATION YEAR", "citation_publication_year");
 	      bundleCitationPds4ToRegistry.put("DESCRIPTION", "citation_description");
       }
+
+	  public static final List<String> authorOrganizationFields =
+		new ArrayList<String>();
+		static {
+			authorOrganizationFields.add("citation_author_organization_name");
+		}
        
+	public static final List<String> authorPersonFields =
+		new ArrayList<String>();
+		static {
+			authorPersonFields.add("citation_author_person_given_name");
+			authorPersonFields.add("citation_author_person_family_name");
+			authorPersonFields.add("citation_author_person_orcid");
+			authorPersonFields.add("citation_author_person_affiliation_organization_name");
+		}
+
+	public static final List<String> editorOrganizationFields =
+		new ArrayList<String>();
+		static {
+			editorOrganizationFields.add("citation_editor_organization_name");
+		}
+		
+	public static final List<String> editorPersonFields =
+		new ArrayList<String>();
+		static {
+			editorPersonFields.add("citation_editor_person_given_name");
+			editorPersonFields.add("citation_editor_person_family_name");
+			editorPersonFields.add("citation_editor_person_orcid");
+			editorPersonFields.add("citation_editor_person_affiliation_organization_name");
+		}
+
 	public static final Map<String, String> bundleContextPds4ToRegistry = 
 	  new LinkedHashMap<String, String>();
 	  static {

--- a/src/main/webapp/pds/viewBundle.jsp
+++ b/src/main/webapp/pds/viewBundle.jsp
@@ -231,6 +231,10 @@
                             out.println("<br>");
                     } // end for
                 } // end if (values!=null)
+
+               if ((key.equals("AUTHORS") || key.equals("EDITORS")) && (values == null || values.size() == 0)) {
+                  out.println(pds4Search.getAuthorsEditors(doc, key));
+               }
             } // end if (key.equals("DOI"))
              %>
              </td>

--- a/src/main/webapp/pds/viewCollection.jsp
+++ b/src/main/webapp/pds/viewCollection.jsp
@@ -224,17 +224,21 @@
                    } // end if (values != null)
                  } // end if nothing from DOI search
              } else {
-                 List<String> values = pds4Search.getValues(doc, tmpValue);
-                 if (values != null) {
-                     for (int j = 0; j < values.size(); j++) {
+               List<String> values = pds4Search.getValues(doc, tmpValue);
+               if (values != null) {
+                  for (int j = 0; j < values.size(); j++) {
 
-                         out.println(values.get(j) + "<br>");
+                        out.println(values.get(j) + "<br>");
 
-                         if (values.size() > 1) {
-                             out.println("<br>");
-                         }
-                     } // end for
-                 } // end if (values!=null)
+                        if (values.size() > 1) {
+                           out.println("<br>");
+                        }
+                  } // end for
+               } // end if (values!=null)
+
+               if ((key.equals("AUTHORS") || key.equals("EDITORS")) && (values == null || values.size() == 0)) {
+                  out.println(pds4Search.getAuthorsEditors(doc, key));
+               }
              } // end if (key.equals("DOI"))
              %>
              </td>

--- a/src/main/webapp/pds/viewDocument.jsp
+++ b/src/main/webapp/pds/viewDocument.jsp
@@ -225,6 +225,10 @@
                          out.println("<br>");
                  } // end for
              } // end if (values!=null)
+
+             if ((key.equals("AUTHORS") || key.equals("EDITORS")) && (values == null || values.size() == 0)) {
+                out.println(pds4Search.getAuthorsEditors(doc, key));
+             }
          } // end if (key.equals("DOI"))
              %>
              </td>

--- a/src/main/webapp/pds/viewProductExternal.jsp
+++ b/src/main/webapp/pds/viewProductExternal.jsp
@@ -234,6 +234,10 @@
                          out.println("<br>");
                  } // end for
              } // end if (values!=null)
+
+            if ((key.equals("AUTHORS") || key.equals("EDITORS")) && (values == null || values.size() == 0)) {
+               out.println(pds4Search.getAuthorsEditors(doc, key));
+            }
          } // end if (key.equals("DOI"))
              %>
              </td>


### PR DESCRIPTION


<!--
    ************************************** REMINDER **************************************
    PR Titles should be "user-friendly". We use these titles
    to populate our Release Notes. Some examples can be found here:
    https://github.com/NASA-PDS/nasa-pds.github.io/wiki/Issue-Tracking#pull-request-titles
-->

## 🗒️ Summary
Depending upon what has been loaded into the registry, ds-view now supports both use cases. Includes updates to bundle, collection, document, and external landing pages

See screenshots below for what it looks like now.

## ⚙️ Test Data and/or Report
<img width="849" alt="Screenshot 2025-05-21 at 4 02 05 PM" src="https://github.com/user-attachments/assets/88721fbc-8c41-4fed-bebb-5e4b266a4021" />

<img width="831" alt="Screenshot 2025-05-21 at 4 02 25 PM" src="https://github.com/user-attachments/assets/0aaa8e04-1f2b-4ce5-b072-4305ffe7c201" />

<img width="849" alt="Screenshot 2025-05-21 at 4 02 44 PM" src="https://github.com/user-attachments/assets/82517d2a-b726-4006-ac1f-11c0b784cab9" />

<img width="841" alt="Screenshot 2025-05-21 at 4 03 01 PM" src="https://github.com/user-attachments/assets/2a17ba87-3c43-420e-af43-378f5557a298" />


## ♻️ Related Issues
<!--
    Reference related issues here and use `Fixes` or `Resolves` in order to automatically close the issue upon merge. For more information on autolinking to tickets see https://docs.github.com/en/github/writing-on-github/autolinked-references-and-urls.

    * for issues in this repo:
        - fixes #1
        - fixes #2
        - refs #3
    * for issues in other repos: NASA-PDS/my_repo#1, NASA-PDS/her_repo#2
-->
refs https://github.com/NASA-PDS/registry-legacy-solr/issues/199